### PR TITLE
Sort import group to fix verify issue

### DIFF
--- a/pkg/cloudprovider/huaweicloud/http.go
+++ b/pkg/cloudprovider/huaweicloud/http.go
@@ -30,8 +30,8 @@ import (
 	"time"
 
 	"k8s.io/client-go/util/flowcontrol"
-	"sigs.k8s.io/cloud-provider-huaweicloud/pkg/apigw/core"
 	"k8s.io/klog"
+	"sigs.k8s.io/cloud-provider-huaweicloud/pkg/apigw/core"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Sort import group after repo transform in order to fix gofmt issue.

```
[root@ecs-d8b6 cloud-provider-huaweicloud]# make verify
hack/verify.sh
diff -u ./pkg/cloudprovider/huaweicloud/http.go.orig ./pkg/cloudprovider/huaweicloud/http.go
--- ./pkg/cloudprovider/huaweicloud/http.go.orig	2020-04-20 08:59:57.771859887 +0800
+++ ./pkg/cloudprovider/huaweicloud/http.go	2020-04-20 08:59:57.771859887 +0800
@@ -30,8 +30,8 @@
 	"time"
 
 	"k8s.io/client-go/util/flowcontrol"
-	"sigs.k8s.io/cloud-provider-huaweicloud/pkg/apigw/core"
 	"k8s.io/klog"
+	"sigs.k8s.io/cloud-provider-huaweicloud/pkg/apigw/core"
 )
 
 const (

Run ./hack/update-gofmt.sh
make: *** [verify] Error 1
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
