### PR TITLE
Add a singer tester to verify authentication information

### DIFF
--- a/pkg/cloudprovider/huaweicloud/throttle.go
+++ b/pkg/cloudprovider/huaweicloud/throttle.go
@@ -262,7 +262,7 @@ func (t *Throttler) syncThrottleFromConfig() {
 
 	fi, err := os.Stat(conf)
 	if err != nil && os.IsNotExist(err) {
-		klog.Warning("Throttle config file is not exist.")
+		klog.V(2).Info("Throttle config file is not exist.")
 		return
 	}
 

--- a/test/signer/README.md
+++ b/test/signer/README.md
@@ -1,0 +1,37 @@
+# Signer
+`Signer` used to verify if your authentication information is correct or suitable for your environment. 
+
+The main process is retrieve a server's name, if the server's name can be retrieved means your authentication is 
+correct and suitable for your environment.
+
+## Quick Start
+
+### Prepare Authentication
+Suppose you have prepared a configuration file as per [configuration guide](../../docs/config/CloudControllerManagerConfiguration.md).
+
+Set your configuration file path to environment, e.g.: 
+```shell script
+export CCMConfigPath=/root/provider/provider.conf
+```
+
+In addition, you need to provide a server ID, e.g.:
+```shell script
+export ServerID=a44af098-7548-4519-8243-a88ba3e5de4f
+``` 
+
+### Run
+Just run following command under `cloud-provider-huaweicloud` home directory as follows:
+```shell script
+[root@ecs-d8b6 cloud-provider-huaweicloud]# go run ./test/signer/v4/main.go 
+Congratulations! Your authentication information is suitable. server name: ecs-d8b6
+```
+
+If everything works fine, you will get a `Congratulations` as well as the server's name. 
+Otherwise, you will see an error message.
+
+## Signer Version
+All request against cloud services should be signed, that usually processed by SDK.
+Different cloud environment rely on specific signature algorithm version. 
+
+Currently, we are using [huaweicloud-sdk-go-v3](https://github.com/huaweicloud/huaweicloud-sdk-go-v3) which rely on 
+signature algorithm `v4`.

--- a/test/signer/v4/main.go
+++ b/test/signer/v4/main.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	huaweicloudsdkbasic "github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/basic"
+	huaweicloudsdkconfig "github.com/huaweicloud/huaweicloud-sdk-go-v3/core/config"
+	huaweicloudsdkecs "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/ecs/v2"
+	huaweicloudsdkecsmodel "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/ecs/v2/model"
+
+	"sigs.k8s.io/cloud-provider-huaweicloud/pkg/cloudprovider/huaweicloud"
+)
+
+const (
+	configPathEnv = "CCMConfigPath"
+	serverIDEnv   = "ServerID"
+)
+
+func readConfigFromEnv() (config *huaweicloud.CloudConfig, serverID string) {
+	configPath := os.Getenv(configPathEnv)
+	if len(configPath) == 0 {
+		fmt.Printf("Please set config file path. e.g. 'export CCMConfigPath=/etc/provider.conf'.\n")
+		return nil, ""
+	}
+
+	fileHandler, err := os.Open(configPath)
+	if err != nil {
+		fmt.Printf("Failed to open file: %s, error: %v\n", configPath, err)
+		return nil, ""
+	}
+	defer fileHandler.Close()
+
+	config, err = huaweicloud.ReadConf(fileHandler)
+	if err != nil {
+		fmt.Printf("Failed to parse config file: %s.\n", configPath)
+		return nil, ""
+	}
+
+	serverID = os.Getenv(serverIDEnv)
+	if len(serverID) == 0 {
+		fmt.Printf("Please set server ID. e.g. 'export ServerID=a44af098-7548-4519-8243-a88ba3e5de4g'.\n")
+		return nil, ""
+	}
+
+	return config, serverID
+}
+
+func main() {
+	config, serverID := readConfigFromEnv()
+	if config == nil || len(serverID) == 0 {
+		return
+	}
+
+	credentials := huaweicloudsdkbasic.NewCredentialsBuilder().
+		WithAk(config.Auth.AccessKey).
+		WithSk(config.Auth.SecretKey).
+		WithProjectId(config.Auth.ProjectID).
+		Build()
+
+	hcClient := huaweicloudsdkecs.EcsClientBuilder().
+		WithEndpoint(config.Auth.ECSEndpoint).
+		WithCredential(credentials).
+		WithHttpConfig(huaweicloudsdkconfig.DefaultHttpConfig()).
+		Build()
+
+	ecsClient := huaweicloudsdkecs.NewEcsClient(hcClient)
+
+	reqOpt := &huaweicloudsdkecsmodel.ShowServerRequest{
+		ServerId: serverID,
+	}
+
+	response, err := ecsClient.ShowServer(reqOpt)
+	if err != nil {
+		fmt.Printf("request failed with error: %v\n", err)
+		return
+	}
+
+	serverName := response.Server.Name
+	fmt.Printf("Congratulations! Your authentication information is suitable. server name: %s\n", serverName)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Added a simple tool to test authentication information. 

Recently, more than one case facing `authentication` failure, it's quite complicated to re-produce, so this tool can ease both user and maintainer's burden.

**Which issue(s) this PR fixes**:
Refer to cases:
- https://github.com/kubernetes-sigs/cloud-provider-huaweicloud/issues/95
- https://github.com/kubernetes-sigs/cloud-provider-huaweicloud/issues/76

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
