### PR TITLE
Fix the issue of calling K8s API with anonymous user

### DIFF
--- a/pkg/cloudprovider/huaweicloud/huaweicloud.go
+++ b/pkg/cloudprovider/huaweicloud/huaweicloud.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/golang-lru"
+	"k8s.io/client-go/rest"
 
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +39,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/cloud-provider"
 	"k8s.io/klog"
@@ -191,6 +191,7 @@ type ELBSessionPersistence struct {
 }
 
 type LBConfig struct {
+	// Deprecated: no longer in use
 	Apiserver    string       `json:"apiserver"`
 	SecretName   string       `json:"secretName"`
 	SignerType   string       `json:"signerType"`
@@ -422,12 +423,13 @@ func NewHWSCloud(config io.Reader) (*HWSCloud, error) {
 	}
 	LogConf(globalConfig)
 
-	clientConfig, err := clientcmd.BuildConfigFromFlags(globalConfig.LoadBalancer.Apiserver, "")
+	clusterCfg, err := rest.InClusterConfig()
 	if err != nil {
+		klog.Errorf("Initial cluster configuration failed with error: %v", err)
 		return nil, err
 	}
 
-	kubeClient, err := corev1.NewForConfig(clientConfig)
+	kubeClient, err := corev1.NewForConfig(clusterCfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The clientConfig initialized by `clientcmd.BuildConfigFromFlags` does not use a token, and will call the API as an anonymous user, which is not secure and may cause an x509 error under the https protocol.

Now use service-account-tokens to initialize the client, which is the same as the service account in DaemonSet file,  and it is more conducive to managing permissions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #116

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
