### PR TITLE
fix omit id field when shareId is empty

### DIFF
--- a/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go
+++ b/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go
@@ -1087,7 +1087,7 @@ func (l *SharedLoadBalancer) createEIP(service *v1.Service) (string, error) {
 	eip, err := l.eipClient.Create(&eipmodel.CreatePublicipRequestBody{
 		Bandwidth: &eipmodel.CreatePublicipBandwidthOption{
 			Name:       &name,
-			Id:         &opts.ShareID,
+			Id:         utils.StringToPtr(opts.ShareID),
 			Size:       &opts.BandwidthSize,
 			ShareType:  shareType,
 			ChargeMode: chargeModel,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -71,3 +71,10 @@ func LookupHost(domain string) []string {
 	klog.Infof("lookup host %s: %s", domain, strings.Join(ns, ", "))
 	return ns
 }
+
+func StringToPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:

This PR Fixes a bug where EIP auto-creation failed for Huawei Cloud ELB services when the `share_id` parameter was not provided in the `kubernetes.io/elb.eip-auto-create-option` annotation.
The Huawei Cloud EIP creation API requires the `id` field in `CreatePublicipBandwidthOption` to be **omitted** (via `nil`) when no `share_id` is specified. Sending an empty string  instead of `nil`  caused EIP creation failures. 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #266 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

`