### PR TITLE
fix providerID format and exclude 127.0.1.1 in node IP selection

### DIFF
--- a/pkg/cloudprovider/huaweicloud/instances.go
+++ b/pkg/cloudprovider/huaweicloud/instances.go
@@ -208,7 +208,7 @@ func (i *Instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 		if err != nil {
 			return nil, err
 		}
-		providerID = id
+		providerID = fmt.Sprintf("%s://%s", ProviderName, id)
 	}
 	instanceID, err := parseInstanceID(providerID)
 	if err != nil {

--- a/pkg/cloudprovider/huaweicloud/wrapper/ecs.go
+++ b/pkg/cloudprovider/huaweicloud/wrapper/ecs.go
@@ -58,7 +58,7 @@ func (e *EcsClient) GetByNodeName(name string) (*model.ServerDetail, error) {
 		privateIP = name
 	} else if ips := utils.LookupHost(name); len(ips) > 0 {
 		for _, ip := range ips {
-			if ip != "127.0.0.1" {
+			if ip != "127.0.0.1" && ip != "127.0.1.1" {
 				privateIP = ip
 				break
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug
**What this PR does / why we need it**:

1. Adds the required huaweicloud:// prefix to the providerID field to ensure correct node registration.
2. Excludes the loopback IP 127.0.1.1 from private IP selection, avoiding misconfiguration in Linux distributions (e.g., Ubuntu) where this IP is auto-configured in /etc/hosts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #268 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
